### PR TITLE
feat: SPT-426 - Added ignore-pr-from-branches input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This action checks that ALL commits present in a pull request include a JIRA ticket. Useful for teams that require an extra level of traceability on their work and tasks. Here is an example:
 
+
 ```yml
 name: CI
 on:
@@ -19,10 +20,30 @@ jobs:
         with:
           base-branch: $GITHUB_BASE_REF
           pr-branch: $GITHUB_HEAD_REF
+          ignore-pr-from-branches:
+            snyk-*
+            other-branch-regex
 ```
 
 The action essentially scans your commit messages [looking](https://stackoverflow.com/questions/19322669/regular-expression-for-a-jira-identifier) for JIRA tickets. In case a commit has no ticket, the action will fail.
 
+## Optional parameter
+
+There is an optional parameter in this action:
+  - ignore-pr-from-branches: List of strings containing regular expressions for PR branch names to ignore.<br />
+  Each regular expression needs to have at least 3 consecutive alphanumeric characters.<br />
+  Input samples:
+      - Multiline input parameter:
+        ```yaml
+        ignore-pr-from-branches:
+          snyk-*
+          other-branch-regex
+        ```
+      - Delimited list:
+        - space: 'snyk-\* other-branch-regex'
+        - semicolon: 'snyk-\*;other-branch-regex'
+        - comma: 'snyk-\*,other-branch-regex'
+      - Json array: '[ \"snyk-\*\", \"other-branch-regex\" ]' 
 ## remarks
 
 :warning: commits that contain `[skip ci]` are skipped from the validation.

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,25 @@ inputs:
   pr-branch:
     description: "name of the branch where the pull request comes from"
     required: true
+  ignore-pr-from-branches:
+    description: | 
+      List of strings containing regular expressions for PR branch names to ignore.
+      Each regular expression needs to have at least 3 consecutive alphanumeric characters.
+      Input samples:
+        - Multiline input parameter:
+          ...
+          ignore-pr-from-branches:
+            snyk-*
+            other-branch-regex
+          ...
+        - Delimited list:
+          - space: 'snyk-* other-branch-regex'
+          - semicolon: 'snyk-*;other-branch-regex'
+          - comma: 'snyk-*,other-branch-regex'
+        - Json array: '[ \"snyk-*\", \"other-branch-regex\" ]' 
+    required: false
 runs:
   using: "composite"
   steps:
-    - run: node ${{ github.action_path }}/ensure-commits-message-jira-ticket.js ${{ inputs.base-branch }} ${{ inputs.pr-branch }}
+    - run: node ${{ github.action_path }}/ensure-commits-message-jira-ticket.js ${{ inputs.base-branch }} ${{ inputs.pr-branch }} '${{ inputs.ignore-pr-from-branches }}'
       shell: bash

--- a/ensure-commits-message-jira-ticket.js
+++ b/ensure-commits-message-jira-ticket.js
@@ -1,14 +1,29 @@
 const git = require("./git.js");
 const logger = require("./logging.js");
+const inputParser = require("./input-param-parse.js");
 const reverse = (str) => str.split("").reverse().join("");
 
 logger.logTitle("ENSURING JIRA TICKETS INTO COMMIT MESSAGES");
 
 const baseBranch = process.argv[2];
 const prBranch = process.argv[3];
+const ignorePrFromBranches = process.argv[4];
 
 logger.logKeyValuePair("base-branch", baseBranch);
 logger.logKeyValuePair("pr-branch", prBranch);
+logger.logKeyValuePair("ignore-pr-from-branches", ignorePrFromBranches);
+
+if (ignorePrFromBranches) {  
+
+  let fromBranchesArray = inputParser.parseStringArray(ignorePrFromBranches,'[a-zA-Z0-9]{3,}','ignore-pr-from-branches')
+  
+  const prBranchMatchAnyIgnoreFromBranch = fromBranchesArray.filter(fb => prBranch.match(fb))
+
+  if (prBranchMatchAnyIgnoreFromBranch.length > 0) {
+    logger.logWarning("Ignoring ensure jira tickets into commit messages, ignore-pr-from-branches matches: " + prBranchMatchAnyIgnoreFromBranch)
+    process.exit(0)
+  }
+}
 
 let ok = git
   .getCommitsInsidePullRequest(baseBranch, `origin/${prBranch}`)

--- a/input-param-parse.js
+++ b/input-param-parse.js
@@ -1,0 +1,57 @@
+const logger = require("./logging.js");
+
+const parseStringArray = (strArray,entryRegex,varName) => {
+  let arrayParsed = parseArray(strArray,varName)
+  const isArray = Array.isArray(arrayParsed)
+
+  if (!isArray){
+    logger.logError(`${varName??'It'} must be an array.`)   
+    process.exit(1)
+  }
+
+  arrayParsed.forEach((element,i) => {
+    logger.logKeyValuePair(`${varName??'Array'}[${i}]`,element)
+  });
+
+  const allElementsAreString = arrayParsed.every(fb => typeof fb === "string" && fb.trim() !== "")
+  if (!allElementsAreString){
+    logger.logError( `${varName??'The'} entries must only contain not empty strings.`)   
+    process.exit(1)
+  }
+
+  if (entryRegex) {
+    const allEntriesFollowRegex = arrayParsed.every(fb => fb.match(entryRegex))
+    if (!allEntriesFollowRegex) {
+      logger.logError(`${varName??'The'} entries needs to follow that regular expression '${entryRegex}'.`)    
+      process.exit(1)
+    }
+  }
+
+  return arrayParsed;
+};
+
+const parseArray = (arrayInput,varName) => {
+
+  let arrayInputTrimmed = arrayInput.trim()
+
+  const isJsonFormatted = arrayInputTrimmed.match(/\[\s*[^\[\]]*?\s*\]/g)
+
+  if(isJsonFormatted){
+    try {
+      return JSON.parse(arrayInputTrimmed)
+    }
+    catch(e){
+      errorMessage = `${varName??'It'} is not a valid json array.`
+      logger.logError(errorMessage)
+      return
+    }
+  }
+  
+  return isJsonFormatted
+    ? JSON.parse(arrayInputTrimmed)
+    : arrayInputTrimmed.split(/(?:,|;| )+/)
+};
+
+module.exports = {
+  parseStringArray
+};


### PR DESCRIPTION
## Description
The Ohpen source check for Jira tickets does not work with SNYK and others automated PRs:

[SNYK autogenerated pr action failed](https://github.com/ohpen/shared-email-lib-dotnet/runs/7853539332?check_suite_focus=true)

In order to allow that kind of pr we think into add a new input parameter 

- ignore-pr-from-branches: List of strings containing regular expressions for PR branch names to ignore.
  Each regular expression needs to have at least 3 consecutive alphanumeric characters.
  Input samples:
    - Multiline input parameter:
      ```yaml
      ignore-pr-from-branches:
        snyk-*
        other-branch-regex
        ```
    - Delimited list:
      - space: 'snyk-\* other-branch-regex'
      - semicolon: 'snyk-\*;other-branch-regex'
      - comma: 'snyk-\*,other-branch-regex'
    - Json array: '[ \"snyk-\*\", \"other-branch-regex\" ]'

## Executions Tests

### Using Automated PR generated by Snyc, commits without jira ticket on comment
- [ignore-pr-from-branches = snyk-*](https://github.com/ohpen/shared-email-lib-dotnet/runs/7897437426?check_suite_focus=true) 
  - _validation skipped_: yes => because pr-branch: snyk-fix-c06228c0569868747054f1daf04fdbdb match with regex: snyk-*
  - _validation result_: N/A
  - _action result_: succeed
![image](https://user-images.githubusercontent.com/94201128/185404716-82b7171a-341a-45cf-8b69-777a93fff22a.png) 
 
- [Without ignore-pr-from-branches](https://github.com/ohpen/shared-email-lib-dotnet/runs/7899686137?check_suite_focus=true)
  - _validation skipped_: no => because we don't use the ignore-pr-from-branches
  - _validation result_: fail => because the autogenerated commit does not have any jira ticket on the message
  - _action result_: fail 
![image](https://user-images.githubusercontent.com/94201128/185405765-a27aee30-739b-4054-ad72-703840815a90.png)

### Using PR from branch with well formatted commits

- [ignore-pr-from-branches => empty list => '[]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7900728103?check_suite_focus=true) 
  - _validation skipped_: no => ignore-pr-from-branches has an empty list
  - _validation result_: succeed => because the commits have jira tickets
  - _action result_: succeed
![image](https://user-images.githubusercontent.com/94201128/185424130-85df8bb8-fdc2-4893-a636-90b1c54b21ca.png)

- [ignore-pr-from-branches => list with empty string entry => '[" "]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7901288798?check_suite_focus=true) 
  - _validation skipped_: N/A
  - _validation result_: N/A  
  - _action result_: fail=> because each entry needs to have at least 3 consecutive alphanumeric characters
![image](https://user-images.githubusercontent.com/94201128/185426088-09424474-0722-4583-82d3-13c845b12046.png)

- [ignore-pr-from-branches => list with les than 3 alphanumeric character => '["fe*"]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7901376203?check_suite_focus=true) 
  - _validation skipped_: N/A
  - _validation result_: N/A  
  - _action result_: fail=> because each entry needs to have at least 3 consecutive alphanumeric characters
![image](https://user-images.githubusercontent.com/94201128/185427406-d8ee690d-03f1-48d1-94c6-a5dd7d258472.png)

- [ignore-pr-from-branches => invalid json list => '["abc";"def"]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7901500539?check_suite_focus=true) 
  - _validation skipped_: N/A
  - _validation result_: N/A  
  - _action result_: fail=> because ignore-pr-from-branches is an invalid json list the entries delimiter needs to be a comma instead of semicolon
![image](https://user-images.githubusercontent.com/94201128/185429119-d359e6b0-e17f-4bf3-bf32-86c139e97c54.png)

- [ignore-pr-from-branches => valid list | no ignore branch matches => '["abc","def"]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7901633259?check_suite_focus=true) 
  - _validation skipped_: no => because any regex on ignore-pr-from-branches list match pr-branch input
  - _validation result_: succeed => because the commits have jira tickets
  - _action result_: succeed
![image](https://user-images.githubusercontent.com/94201128/185430702-bcb6b14e-0118-4651-bd02-2019e2a2d1bf.png)

- [ignore-pr-from-branches => valid list | ignore branch matches => '["fea*","SPT*"]'](https://github.com/ohpen/shared-email-lib-dotnet/runs/7901756425?check_suite_focus=true) 
  - _validation skipped_: yes=> because more than one regex on ignore-pr-from-branches list match pr-branch input
  - _validation result_: N/A
  - _action result_: succeed
![image](https://user-images.githubusercontent.com/94201128/185432273-8e1166fb-62cc-436b-9dab-cd99b3355c37.png)


  



  



  

